### PR TITLE
Implemented feature to pull data from GitLab repositories

### DIFF
--- a/src/main/java/client/GitLabClient.java
+++ b/src/main/java/client/GitLabClient.java
@@ -1,0 +1,28 @@
+package client;
+
+import network.RequestSender;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+public class GitLabClient {
+    private static final String REPOSITORY_ZIPBALL_URL_TEMPLATE = "%s/api/v4/projects/%s/repository/archive.zip";
+
+    private final RequestSender requestSender;
+
+    public GitLabClient(RequestSender requestSender) {
+        this.requestSender = requestSender;
+    }
+
+    public byte[] downloadRepoAsZip(String repositoryUrl, String repositoryId, String apiKey) {
+        String trimmedRepositoryUrl = repositoryUrl.trim().replaceAll("/$", "");
+        String url = REPOSITORY_ZIPBALL_URL_TEMPLATE.formatted(trimmedRepositoryUrl, repositoryId);
+
+        Map<String, String> headers = apiKey != null && !apiKey.isBlank() ?
+                Map.of("PRIVATE-TOKEN", apiKey) :
+                emptyMap();
+
+        return requestSender.sendRequest(url, headers).body().getBytes();
+    }
+}

--- a/src/main/java/repository/GitLabRepository.java
+++ b/src/main/java/repository/GitLabRepository.java
@@ -1,0 +1,57 @@
+package repository;
+
+import client.GitLabClient;
+import data.Item;
+import data.ItemFactory;
+import data.RepositoryMetadata;
+import file.finder.FileFinder;
+import file.temp.TempFileCreator;
+import file.zip.ZipExtractor;
+import settings.repository.gitlab.GitLabSettingsReader;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public class GitLabRepository<T extends Item> implements Repository<T> {
+    private final GitLabClient gitLabClient;
+    private final TempFileCreator tempFileCreator;
+    private final ZipExtractor zipExtractor;
+    private final FileFinder fileFinder;
+    private final GitLabSettingsReader gitLabSettings;
+    private final RepositoryMetadata repositoryMetadata;
+    private final ItemFactory<T> itemFactory;
+
+    public GitLabRepository(
+            ItemFactory<T> itemFactory,
+            GitLabClient gitLabClient,
+            TempFileCreator tempFileCreator,
+            ZipExtractor zipExtractor,
+            FileFinder fileFinder,
+            GitLabSettingsReader gitLabSettings,
+            RepositoryMetadata repositoryMetadata) {
+        this.itemFactory = itemFactory;
+        this.gitLabClient = gitLabClient;
+        this.tempFileCreator = tempFileCreator;
+        this.zipExtractor = zipExtractor;
+        this.fileFinder = fileFinder;
+        this.gitLabSettings = gitLabSettings;
+        this.repositoryMetadata = repositoryMetadata;
+    }
+
+    @Override
+    public List<T> loadAllItems() {
+        Path downloadLocation = tempFileCreator.createTempDirectory(repositoryMetadata.getTempDirectoryPrefix());
+        byte[] itemsAsZip = gitLabClient.downloadRepoAsZip(
+                gitLabSettings.repositoryUrl(),
+                gitLabSettings.repositoryName(),
+                gitLabSettings.apiKey()
+        );
+
+        zipExtractor.extractZip(itemsAsZip, downloadLocation);
+
+        return fileFinder.find(downloadLocation, repositoryMetadata.getFileExtension())
+                .stream()
+                .map(itemFactory::fromFile)
+                .toList();
+    }
+}

--- a/src/main/java/repository/RepositoryFacade.java
+++ b/src/main/java/repository/RepositoryFacade.java
@@ -8,14 +8,17 @@ import java.util.List;
 public class RepositoryFacade<T extends Item> implements Repository<T> {
     private final FileSystemRepository<T> fileSystemRepository;
     private final GitHubRepository<T> gitHubRepository;
+    private final GitLabRepository<T> gitLabRepository;
     private final RepositorySettingsReader repositorySettingsReader;
 
     public RepositoryFacade(
             RepositorySettingsReader repositorySettingsReader,
             GitHubRepository<T> gitHubRepository,
+            GitLabRepository<T> gitLabRepository,
             FileSystemRepository<T> fileSystemRepository) {
         this.fileSystemRepository = fileSystemRepository;
         this.gitHubRepository = gitHubRepository;
+        this.gitLabRepository = gitLabRepository;
         this.repositorySettingsReader = repositorySettingsReader;
     }
 
@@ -24,6 +27,7 @@ public class RepositoryFacade<T extends Item> implements Repository<T> {
         Repository<T> repository =  switch (repositorySettingsReader.repositoryType()) {
             case FILESYSTEM -> fileSystemRepository;
             case GITHUB -> gitHubRepository;
+            case GITLAB -> gitLabRepository;
         };
 
         return repository.loadAllItems();

--- a/src/main/java/repository/RepositoryFacadeFactory.java
+++ b/src/main/java/repository/RepositoryFacadeFactory.java
@@ -2,6 +2,7 @@ package repository;
 
 import burp.api.montoya.http.Http;
 import client.GitHubClient;
+import client.GitLabClient;
 import data.Item;
 import data.ItemFactory;
 import data.RepositoryMetadata;
@@ -26,6 +27,7 @@ public class RepositoryFacadeFactory {
                                RepositoryMetadata repositoryMetadata) {
         RequestSender requestSender = new RequestSender(http, logger);
         GitHubClient gitHubClient = new GitHubClient(requestSender);
+        GitLabClient gitLabClient = new GitLabClient(requestSender);
         TempFileCreator tempFileCreator = new TempFileCreator(logger);
         ZipExtractor zipExtractor = new ZipExtractor(logger);
         FileFinder fileFinder = new FileFinder();
@@ -40,6 +42,16 @@ public class RepositoryFacadeFactory {
                 repositoryMetadata
         );
 
+        GitLabRepository<T> gitLabRepository = new GitLabRepository<>(
+                itemFactory,
+                gitLabClient,
+                tempFileCreator,
+                zipExtractor,
+                fileFinder,
+                settingsController.gitLabSettings(),
+                repositoryMetadata
+        );
+
         FileSystemRepository<T> fileSystemRepository = new FileSystemRepository<>(
                 settingsController.fileSystemRepositorySettings(),
                 fileFinder,
@@ -51,6 +63,7 @@ public class RepositoryFacadeFactory {
         return new RepositoryFacade<>(
                 settingsController.repositorySettings(),
                 gitHubRepository,
+                gitLabRepository,
                 fileSystemRepository
         );
     }

--- a/src/main/java/repository/RepositoryType.java
+++ b/src/main/java/repository/RepositoryType.java
@@ -4,7 +4,8 @@ import static java.util.Arrays.stream;
 
 public enum RepositoryType {
     FILESYSTEM("Filesystem", "filesystem"),
-    GITHUB("GitHub", "github");
+    GITHUB("GitHub", "github"),
+    GITLAB("GitLab", "gitlab");
 
     public final String displayName;
     public final String persistedKey;

--- a/src/main/java/settings/controller/ItemSettingsController.java
+++ b/src/main/java/settings/controller/ItemSettingsController.java
@@ -6,17 +6,20 @@ import settings.defaultsavelocation.DefaultSaveLocationSettings;
 import settings.repository.RepositorySettings;
 import settings.repository.filesystem.FileSystemRepositorySettings;
 import settings.repository.github.GitHubSettings;
+import settings.repository.gitlab.GitLabSettings;
 
 public class ItemSettingsController {
     private final DefaultSaveLocationSettings defaultSaveLocationSettings;
     private final RepositorySettings repositorySettings;
     private final GitHubSettings gitHubSettings;
+    private final GitLabSettings gitLabSettings;
     private final FileSystemRepositorySettings fileSystemRepositorySettings;
 
     public ItemSettingsController(Preferences preferences, ItemMetadata itemMetadata) {
         this.defaultSaveLocationSettings = new DefaultSaveLocationSettings(preferences, itemMetadata);
         this.repositorySettings = new RepositorySettings(preferences, itemMetadata);
         this.gitHubSettings = new GitHubSettings(preferences, itemMetadata);
+        this.gitLabSettings = new GitLabSettings(preferences, itemMetadata);
         this.fileSystemRepositorySettings = new FileSystemRepositorySettings(preferences, itemMetadata);
     }
 
@@ -30,6 +33,10 @@ public class ItemSettingsController {
 
     public GitHubSettings gitHubSettings() {
         return gitHubSettings;
+    }
+
+    public GitLabSettings gitLabSettings() {
+        return gitLabSettings;
     }
 
     public FileSystemRepositorySettings fileSystemRepositorySettings() {

--- a/src/main/java/settings/repository/gitlab/GitLabSettings.java
+++ b/src/main/java/settings/repository/gitlab/GitLabSettings.java
@@ -1,0 +1,43 @@
+package settings.repository.gitlab;
+
+import burp.api.montoya.persistence.Preferences;
+import data.RepositoryMetadata;
+import settings.AbstractSettings;
+
+public class GitLabSettings extends AbstractSettings implements GitLabSettingsReader {
+    private static final String GITLAB_API_URL = "https://gitlab.com";
+    private static final String API_KEY_KEY = "gitlab_settings.api_key";
+    private final RepositoryMetadata repositoryMetadata;
+
+    public GitLabSettings(Preferences preferences, RepositoryMetadata repositoryMetadata) {
+        super(preferences);
+        this.repositoryMetadata = repositoryMetadata;
+    }
+
+    @Override
+    public String repositoryUrl() {
+        return loadStringFromPreferences("gitlab_" + repositoryMetadata.getRepositoryUrlKey(), GITLAB_API_URL);
+    }
+
+    public void setRepositoryUrl(String repositoryUrl) {
+        saveStringToPreferences("gitlab_" + repositoryMetadata.getRepositoryUrlKey(), repositoryUrl);
+    }
+
+    @Override
+    public String repositoryName() {
+        return loadStringFromPreferences("gitlab_" + repositoryMetadata.getRepositoryNameKey(), repositoryMetadata.getDefaultRepositoryNameValue());
+    }
+
+    public void setRepositoryName(String repositoryName) {
+        saveStringToPreferences("gitlab_" + repositoryMetadata.getRepositoryNameKey(), repositoryName);
+    }
+
+    @Override
+    public String apiKey() {
+        return loadStringFromPreferences(API_KEY_KEY, null);
+    }
+
+    public void setApiKey(String apiKey) {
+        saveStringToPreferences(API_KEY_KEY, apiKey);
+    }
+}

--- a/src/main/java/settings/repository/gitlab/GitLabSettingsReader.java
+++ b/src/main/java/settings/repository/gitlab/GitLabSettingsReader.java
@@ -1,0 +1,9 @@
+package settings.repository.gitlab;
+
+public interface GitLabSettingsReader {
+    String repositoryUrl();
+
+    String repositoryName();
+
+    String apiKey();
+}

--- a/src/main/java/ui/view/pane/settings/GitLabRepositorySettingsSubComponent.java
+++ b/src/main/java/ui/view/pane/settings/GitLabRepositorySettingsSubComponent.java
@@ -1,0 +1,121 @@
+package ui.view.pane.settings;
+
+import settings.repository.gitlab.GitLabSettings;
+import ui.view.listener.SingleHandlerDocumentListener;
+
+import javax.swing.*;
+import java.awt.*;
+
+import static java.awt.GridBagConstraints.FIRST_LINE_START;
+
+class GitLabRepositorySettingsSubComponent extends JPanel {
+    private final JLabel descriptionLabelSecondLine = new JLabel("If the repo isn't public, you'll need to specify an API key too. You can look at GitLab's documentation to find out how to create one.");
+    private final JLabel descriptionLabelThirdLine = new JLabel("If you're using the same API key across multiple applications, you might exceed GitLab's rate limit, meaning that this extension will no longer work until the rate limit resets.");
+    private final JLabel repoNameDescription = new JLabel("GitLab Project ID (integer value)");
+    private final JLabel repoUrlDescription = new JLabel("GitLab URL");
+    private final JLabel apiKeyDescription = new JLabel("API key (only needed if it is a private repo)");
+    private final JTextField repoNameField = new JTextField();
+    private final JTextField repoUrlField = new JTextField();
+    private final JTextField apiKeyField = new JTextField();
+
+    private final GitLabSettings gitLabSettings;
+
+    GitLabRepositorySettingsSubComponent(GitLabSettings gitLabSettings) {
+        this.gitLabSettings = gitLabSettings;
+
+        initialiseUi();
+    }
+
+    private void initialiseUi() {
+        setupLayout();
+
+        setupRepoNameField();
+        setupRepoURLField();
+        setupApiKeyField();
+
+        addElements();
+    }
+
+    private void setupLayout() {
+        GridBagLayout layout = new GridBagLayout();
+        layout.columnWidths = new int[]{0, 20, 0};
+        layout.rowHeights = new int[]{0, 5, 0, 30, 0, 15, 0, 15, 0};
+
+        setLayout(layout);
+    }
+
+    private void setupRepoNameField() {
+        repoNameField.setText(gitLabSettings.repositoryName());
+        repoNameField.setColumns(40);
+        repoNameField.getDocument().addDocumentListener(
+                new SingleHandlerDocumentListener(e -> gitLabSettings.setRepositoryName(repoNameField.getText()))
+        );
+    }
+
+    private void setupRepoURLField() {
+        repoUrlField.setText(gitLabSettings.repositoryUrl());
+        repoUrlField.setColumns(40);
+        repoUrlField.getDocument().addDocumentListener(
+                new SingleHandlerDocumentListener(e -> gitLabSettings.setRepositoryUrl(repoUrlField.getText()))
+        );
+    }
+
+    private void setupApiKeyField() {
+        apiKeyField.setText(gitLabSettings.apiKey());
+        apiKeyField.setColumns(40);
+        apiKeyField.getDocument().addDocumentListener(
+                new SingleHandlerDocumentListener(e -> gitLabSettings.setApiKey(apiKeyField.getText()))
+        );
+    }
+
+    private void addElements() {
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridy = 0;
+        constraints.gridwidth = 3;
+        add(descriptionLabelSecondLine, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridy = 2;
+        constraints.gridwidth = 3;
+        add(descriptionLabelThirdLine, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridy = 4;
+        add(repoUrlDescription, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridx = 2;
+        constraints.gridy = 4;
+        constraints.weightx = 1;
+        add(repoUrlField, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridy = 6;
+        add(repoNameDescription, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridx = 2;
+        constraints.gridy = 6;
+        constraints.weightx = 1;
+        add(repoNameField, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridy = 8;
+        add(apiKeyDescription, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.anchor = FIRST_LINE_START;
+        constraints.gridx = 2;
+        constraints.gridy = 8;
+        constraints.insets = new Insets(0, 0, 10, 0);
+
+        add(apiKeyField, constraints);
+    }
+}

--- a/src/main/java/ui/view/pane/settings/RepositorySettingsComponent.java
+++ b/src/main/java/ui/view/pane/settings/RepositorySettingsComponent.java
@@ -5,6 +5,7 @@ import repository.RepositoryType;
 import settings.repository.RepositorySettings;
 import settings.repository.filesystem.FileSystemRepositorySettings;
 import settings.repository.github.GitHubSettings;
+import settings.repository.gitlab.GitLabSettings;
 
 import javax.swing.*;
 import java.awt.*;
@@ -16,6 +17,7 @@ class RepositorySettingsComponent implements SettingsComponent {
     private final JPanel component;
     private final RepositorySettings repositorySettings;
     private final GitHubSettings gitHubSettings;
+    private final GitLabSettings gitLabSettings;
     private final FileSystemRepositorySettings fileSystemRepositorySettings;
     private final NameMetadata nameMetadata;
 
@@ -23,10 +25,12 @@ class RepositorySettingsComponent implements SettingsComponent {
 
     RepositorySettingsComponent(RepositorySettings repositorySettings,
                                 GitHubSettings gitHubSettings,
+                                GitLabSettings gitLabSettings,
                                 FileSystemRepositorySettings fileSystemRepositorySettings,
                                 NameMetadata nameMetadata) {
         this.repositorySettings = repositorySettings;
         this.gitHubSettings = gitHubSettings;
+        this.gitLabSettings = gitLabSettings;
         this.fileSystemRepositorySettings = fileSystemRepositorySettings;
         this.nameMetadata = nameMetadata;
         component = new JPanel();
@@ -82,6 +86,7 @@ class RepositorySettingsComponent implements SettingsComponent {
         subComponent = switch (repositoryType) {
             case GITHUB -> new GitHubRepositorySettingsSubComponent(gitHubSettings);
             case FILESYSTEM -> new FileSystemRepositorySettingsSubComponent(fileSystemRepositorySettings);
+            case GITLAB -> new GitLabRepositorySettingsSubComponent(gitLabSettings);
         };
 
         component.add(subComponent, constraints);

--- a/src/main/java/ui/view/pane/settings/Settings.java
+++ b/src/main/java/ui/view/pane/settings/Settings.java
@@ -19,6 +19,7 @@ public class Settings extends JTabbedPane {
                         new RepositorySettingsComponent(
                                 settingsController.bCheckSettingsController().repositorySettings(),
                                 settingsController.bCheckSettingsController().gitHubSettings(),
+                                settingsController.bCheckSettingsController().gitLabSettings(),
                                 settingsController.bCheckSettingsController().fileSystemRepositorySettings(),
                                 BCHECK
                         )
@@ -35,6 +36,7 @@ public class Settings extends JTabbedPane {
                         new RepositorySettingsComponent(
                                 settingsController.bambdaSettingsController().repositorySettings(),
                                 settingsController.bambdaSettingsController().gitHubSettings(),
+                                settingsController.bambdaSettingsController().gitLabSettings(),
                                 settingsController.bambdaSettingsController().fileSystemRepositorySettings(),
                                 BAMBDA
                         )


### PR DESCRIPTION
Hello there. Thank you for this Burp Extension! I extended it with the capability to also load BChecks and Bambdas from Gitlab. I tried to change as little as possible on your code and added this feature just as an additional setting.

The difference are some small differences between how the data is accessed on GitLab and GitHub. The API for GitLab uses the project ID (can be found in the repository) and it uses a different HTTP-Header for authentication than the API of GitHub.

I've created a test repository for this with the URL https://gitlab.com/raphael.heer/test-project-for-burp-bchecks. You can use it to test my PR by setting following two values in the settings:
GitLab URL: https://www.gitlab.com
Project ID: 83892477